### PR TITLE
サインイン機能実装

### DIFF
--- a/components/AuthForm/index.tsx
+++ b/components/AuthForm/index.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import styles from "./styles.module.css";
 import { useForm } from "react-hook-form";
 import { signupFormType } from "@/type/authFormType";
-import { signUpWithEmail } from "@/utils/firebase/auth";
+import { signInWithEmail, signUpWithEmail } from "@/utils/firebase/auth";
 import { useRouter } from "next/navigation";
 
 type Props = {
@@ -44,21 +44,35 @@ const AuthForm = ({ isSignUp }: Props) => {
 
   const onSubmit = async (data: signupFormType) => {
     const { name, email, password } = data;
-    try {
-      const response = await signUpWithEmail(email, password);
-      const userId = response.user.uid;
-      await createUser(userId, name, email);
-      router.push("/");
-      router.refresh();
-    } catch (error: any) {
-      if (
-        error.message === "このメールアドレスは既に使用されています" ||
-        error.message === "無効なメールアドレスです"
-      ) {
-        setError("email", { message: error.message });
-      } else if (error.message === "パスワードは6文字以上にしてください") {
-        setError("password", { message: error.message });
-      } else {
+
+    if (isSignUp) {
+      // 新規ユーザー登録処理
+      try {
+        const response = await signUpWithEmail(email, password);
+        const userId = response.user.uid;
+        await createUser(userId, name, email);
+        router.push("/");
+        router.refresh();
+      } catch (error: any) {
+        if (
+          error.message === "このメールアドレスは既に使用されています" ||
+          error.message === "無効なメールアドレスです"
+        ) {
+          setError("email", { message: error.message });
+        } else if (error.message === "パスワードは6文字以上にしてください") {
+          setError("password", { message: error.message });
+        } else {
+          setError("root", { message: error.message });
+        }
+      }
+    } else {
+      // ログイン処理
+      try {
+        await signInWithEmail(email, password);
+
+        router.push("/");
+        router.refresh();
+      } catch (error: any) {
         setError("root", { message: error.message });
       }
     }

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -48,8 +48,6 @@ const Header = () => {
 
               <li className={`${styles.signIn} ${styles.pcOnly}`}>
                 {isLogin ? (
-                  // テスト用に簡易的にログアウトも実装
-                  // 別のタスクでログアウト機能実装した場合この記述は不要
                   <button onClick={async () => await signOut(auth)} className={`${styles.signOut}`}>
                     log out
                   </button>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -25,7 +25,7 @@ const Header = () => {
                 </Link>
               </li>
               <li className={`${styles.signIn} ${styles.pcOnly}`}>
-                <Link href="/signIn">sign in</Link>
+                <Link href="/signin">sign in</Link>
               </li>
             </ul>
           </nav>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,31 +1,61 @@
+"use client";
+
+import { onAuthStateChanged, signOut } from "firebase/auth";
 import styles from "./styles.module.css";
 import Link from "next/link";
 // import Image from "next/image";
 // import Icon from "./img/icon-create.svg";
 import { FaPenAlt } from "react-icons/fa";
+import { auth } from "@/utils/firebase/config";
+import { useEffect, useState } from "react";
 
 const Header = () => {
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [isLogin, setIsLogin] = useState(false);
+  useEffect(() => {
+    onAuthStateChanged(auth, (user) => {
+      if (user) {
+        setIsLogin(true);
+        setUserEmail(user?.email);
+      } else {
+        setIsLogin(false);
+        setUserEmail(null);
+      }
+    });
+  }, []);
+
   return (
     <>
       <header className={styles.header}>
         <div className={styles.wrap}>
           <h1>logo</h1>
-
+          {isLogin && userEmail && <p>{userEmail}</p>}
           <nav className={styles.nav}>
             <ul>
               <li className={styles.pcOnly}>
                 <Link href="/">home</Link>
               </li>
-              <li>
-                <Link href="/create">
-                  <span className={styles.icon}>
-                    <FaPenAlt size={15} />
-                  </span>
-                  create
-                </Link>
-              </li>
+              {isLogin && (
+                <li>
+                  <Link href="/create">
+                    <span className={styles.icon}>
+                      <FaPenAlt size={15} />
+                    </span>
+                    create
+                  </Link>
+                </li>
+              )}
+
               <li className={`${styles.signIn} ${styles.pcOnly}`}>
-                <Link href="/signin">sign in</Link>
+                {isLogin ? (
+                  // テスト用に簡易的にログアウトも実装
+                  // 別のタスクでログアウト機能実装した場合この記述は不要
+                  <button onClick={async () => await signOut(auth)} className={`${styles.signOut}`}>
+                    log out
+                  </button>
+                ) : (
+                  <Link href="/signin">sign in</Link>
+                )}
               </li>
             </ul>
           </nav>

--- a/components/Header/styles.module.css
+++ b/components/Header/styles.module.css
@@ -47,6 +47,24 @@ nav li.signIn {
   color: #333;
 }
 
+nav li.signIn a {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+nav li.signIn .signOut {
+  background-color: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 /* アイコン */
 .icon {
   width: 22px;

--- a/utils/firebase/auth.ts
+++ b/utils/firebase/auth.ts
@@ -1,4 +1,4 @@
-import { createUserWithEmailAndPassword } from "firebase/auth";
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "./config";
 
 export const signUpWithEmail = async (email: string, password: string) => {
@@ -26,5 +26,25 @@ export const signUpWithEmail = async (email: string, password: string) => {
     }
 
     throw new Error(errorMessage);
+  }
+};
+
+export const signInWithEmail = async (email: string, password: string) => {
+  try {
+    const user = await signInWithEmailAndPassword(auth, email, password);
+    return user;
+  } catch (error: any) {
+    let errorMessage = "サインインに失敗しました";
+    if (error.code) {
+      switch (error.code) {
+        case "auth/invalid-credential":
+          errorMessage = "メールアドレスかパスワードが間違っています";
+          break;
+        default:
+          errorMessage = "予期しないエラーが発生しました";
+          break;
+      }
+      throw new Error(errorMessage);
+    }
   }
 };


### PR DESCRIPTION
close #54 

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）

- 「utils\firebase\auth.ts」でsignInWithEmail関数を作成
- 「components\AuthForm\index.tsx」で、propsで渡されたisSignUpがfalseの場合にsignInWithEmailを実行するようにした

### テストユーザー
test1@test.com　123456
test2@test.com　123456
test3@test.com　123456
test4@test.com　123456
test5@test.com　123456

### 正常にサインインしているかの確認
- 確認のため「components\Header\index.tsx」で認証情報を受け取っている
- ログインユーザーのメールアドレスを表示
- ログインしていない場合は「Create」ボタンを非表示
- ログイン状態に応じて「Sign In」ボタンと「Log Out」ボタンを切り替え
![image](https://github.com/user-attachments/assets/55b481fc-6596-4869-b1e9-9376a33285f4)


- テスト用にログアウト処理も簡易的に実装している。#55 をマージする際には削除する想定

### 認証情報が間違っている際にエラーを表示させるようにした
![image](https://github.com/user-attachments/assets/47fd0757-b533-4d5c-b2d8-dfcf30c7757d)


## レビュー観点（レビューをする際に見てほしい点など）

- firebase authenticationを初めて実装したので基本的な使い方が間違っていないか確認お願いします（特にログイン後のユーザー情報の取得）
